### PR TITLE
Fix security misconfiguration

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -27,6 +27,11 @@ def create_app(config=None):
     else:
         app.config.from_pyfile("config.py")
 
+    if not app.config.get("TESTING") and app.config.get("SECRET_KEY") == "default_secret_key":
+        raise ValueError(
+            "SECRET_KEY is using the insecure default. Set the SECRET_KEY environment variable."
+        )
+
     db.init_app(app)
     login_manager.init_app(app)
     migrate.init_app(app, db)

--- a/instance/config.py
+++ b/instance/config.py
@@ -1,7 +1,9 @@
 import os
 
-SECRET_KEY = os.getenv('SECRET_KEY', 'default_secret_key')
-SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL', 'sqlite:///helpdesk.db')
+SECRET_KEY = os.getenv("SECRET_KEY", "default_secret_key")
+SQLALCHEMY_DATABASE_URI = os.getenv("DATABASE_URL", "sqlite:///helpdesk.db")
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 
-DEBUG = True
+# Allow debug mode to be toggled via an environment variable. It defaults to
+# False to avoid running in debug mode unintentionally in production.
+DEBUG = os.getenv("FLASK_DEBUG", "False").lower() in ("1", "true", "t")

--- a/run.py
+++ b/run.py
@@ -1,6 +1,8 @@
+import os
 from app import create_app
 
 app = create_app()
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=5000, debug=True)
+    debug_flag = os.getenv("FLASK_DEBUG", "False").lower() in ("1", "true", "t")
+    app.run(host="0.0.0.0", port=5000, debug=debug_flag)


### PR DESCRIPTION
## Summary
- make debug mode configurable via env vars
- prevent running with default SECRET_KEY

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850550f95b08324856b4046597ca2fe